### PR TITLE
Abaccus python3 upgrade + minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
-# Abaccus v1.0
+# Abaccus v1.1
 
 **Description**
 
-Abaccus is a python-based script for the detection of Horizontal Gene Transfer (HGT) events. 
-Version 1.0 is the initial version of the script as described in Naranjo-Ortiz et al (2016). 
+Abaccus is a python-based script for the detection of Horizontal Gene Transfer (HGT) events.
+Version 1.1 is the Python3-compatible version of the script as described in Naranjo-Ortiz et al (2016).
 
 **Requirements:**
 
-All dependencies should be installed before running the script: python (www.python.org) and ETE2 package (http://www.http://etetoolkit.org/). 
+All dependencies should be installed before running the script: python (www.python.org) and ETE3 package (http://etetoolkit.org).
 
 **Input:**
 
-The program requires a **phylogenetic tree** representing the evolution of a gene family, and a .csv file containing a **taxonomy** to be used as a reference (i.e taxonomy.csv, included in this folder, set as default). The **taxonomy** should include at least all species contained in the **phylogenetic tree**. The **phylogenetic tree** can be provided in standard **newick** format, or as provided by the **phylomizer pipeline** (https://github.com/Gabaldonlab/phylomizer). 
+The program requires a **phylogenetic tree** representing the evolution of a gene family, and a .csv file containing a **taxonomy** to be used as a reference (i.e taxonomy.csv, included in this folder, set as default). The **taxonomy** should include at least all species contained in the **phylogenetic tree**. The **phylogenetic tree** can be provided in standard **newick** format, or as provided by the **phylomizer pipeline** (https://github.com/Gabaldonlab/phylomizer).
 
 In any case, unless specified by the user, the program will assume that the name of the central sequence of the tree is contained in the name of the directory containing the tree (if used as input), and/or the newick tree analyzed. Currently, the script assumes that sequences use a Uniprot-like nomenclature system, with an alphanumerical ID value, followed by a mnemonic code of the species separated by underscore (I. e I7M603_TETTS; where I7MG03 is the Uniprot ID and TETTS is a mnemonic code for *Tetrahymena termophila*).
 
 **Output:**
 
-Abaccus reports a raw text summarizing the number of loses needed to explain the phylogenetic distribution assuming exclusively vertical inheritance, the taxonomic levels at which the loses are predicted, and a printed version of the subtree containing the predicted transfered group as well as the branches in which it is embedded (sister branch and the sister branch to the common ancestor of the event + sister branch).
+Abaccus reports a raw text summarizing the number of loses needed to explain the phylogenetic distribution assuming exclusively vertical inheritance, the taxonomic levels at which the loses are predicted, and a printed version of the subtree containing the predicted transferred group as well as the branches in which it is embedded (sister branch and the sister branch to the common ancestor of the event + sister branch).
 
 **Other options:**
 To see the rest of the options, just type:
@@ -37,10 +37,10 @@ In order to launch the script with the examples, just use as input any of the tr
 In this example, the program will create a file called abacus_output.txt with the results if it doesn't exists already. If it does, it will just append the output to the existing file. To send the results to STDOUT, use the -v or --verbose flag.
 
 The included examples are the following:
-  
+
   1) Example1 contains a well described horizontal gene transfer event in *Schizosaccharomyces pombe*, containing two highly related alanine racemases.
-  
+
   2) Example2 contains a putative event described in Naranjo-Ortiz, et al (2016). Is a complex event involving a primary transfer of an aspartate-glutamate-hydantoin racemase from bacteria to fungi, and an uncertain number of secondary transferences between different fungal clades.
-  
-  3) Example3 contains a possible transference of an aspartate-glutamate-hydantoin racemase in the foraminiferan *Reticulomyxa 
+
+  3) Example3 contains a possible transference of an aspartate-glutamate-hydantoin racemase in the foraminiferan *Reticulomyxa
   filosa*. While the topology of the tree suggest a very possible horizontal gene transfer, abaccus will reject the event based on the lack of representation of related organisms. Negative control.

--- a/abaccus.py
+++ b/abaccus.py
@@ -1,13 +1,15 @@
 #!/bin/python
 
-'''Abaccus will incorporate taxonomic information in order to infer the 
-minimal number of loses that would explain a given taxonomic distribution
+'''Abaccus will incorporate taxonomic information in order to infer the
+minimal number of losses that would explain a given taxonomic distribution
 assuming only vertical inheritance.'''
 
-from ete2 import Tree
-import sys, re, os.path
+from ete3 import Tree
+import sys
+import re
+import os.path
 import argparse
-from os.path import dirname
+# from os.path import dirname (never used)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -16,33 +18,33 @@ if __name__ == '__main__':
     parser.add_argument('-o', '--output', default="abaccus_output.txt", help="Name of the output file")
     parser.add_argument('-t', '--taxonomy', default="./taxonomy.csv", help="Name of the file containing the taxonomic information of each species in the dataset")
     parser.add_argument('-J', '--jumps', default=2, type=int, help="Minimum number of unshared taxa between one branch of the tree and its sister branch, to be considered suspicious of beeing en event")
-    parser.add_argument('-L', '--loses', default=3, type=int, help="Number of loses needed to be considered a potential event.")
-    parser.add_argument('-R', '--rounds', default=6, type=int, help="It sets the number 'r' of times the algorythm will explore parent nodes. If they iterate r times without finding anything suspicious, the program will stop. This parameter aims to prevent false positives by limiting the explored space to the closest relatives to the central sequence.")
+    parser.add_argument('-L', '--losses', default=3, type=int, help="Number of losses needed to be considered a potential event.")
+    parser.add_argument('-R', '--rounds', default=6, type=int, help="It sets the number 'r' of times the algorithm will explore parent nodes. If they iterate r times without finding anything suspicious, the program will stop. This parameter aims to prevent false positives by limiting the explored space to the closest relatives to the central sequence.")
     parser.add_argument('-X', '--exceptions', default=2, type=int, help="Number of acceptable consecutive breaks of monophily. The program will sample the tree when it arrives to this number. This number must be necessarily equal or lower than 'exceptions'.")
     parser.add_argument('-S', '--strikes', default=3, type=int, help="Number of acceptable non-consecutive breaks of monophily. The program will sample the tree when it arrives to this number. This number must be necessarily equal or higher than 'exceptions'.")
     parser.add_argument('-v', '--verbose', action='store_true', help="Prints the result onscreen instead of redirecting it to a file")
     parser.add_argument('-b', '--branch_support', default=0.9, type=float)
-        
+
 args = parser.parse_args()
 
 if args.input[-1] == "/":
 	args.input = args.input[:-1]
 
 if args.strikes < args.exceptions:
-	print "Error: Strikes must be equal or lower than Exceptions. Remember that every Exception is an strike. but not every strike is an exception!"
+	print("Error: Strikes must be equal or lower than Exceptions. Remember that	every Exception is an strike. but not every strike is an exception!")
 	sys.exit()
-	
+
 if args.branch_support > 1.0:
-	print "Branch support is a fraction of 1, so you cannot give a value above that. Your value was: "+str(args.branch)
+	print("Branch support is a fraction of 1, so you cannot give a value above that. Your value was: ") + str(args.branch)
 	sys.exit()
-  
+
 
 
 if os.path.isdir(args.input) == True:
 	for element in os.listdir(args.input):
 		if element.find(".tree.phyml.rank.nj") > -1:
 			rank = args.input + "/" + element
-			break 			
+			break
 	rankfile = open(rank)
 
 	model = str(rankfile.readline()).split()[0]
@@ -59,9 +61,9 @@ if os.path.isdir(args.input) == True:
 		if os.path.isfile(attempt2) == True:
 			chosen_model_tree = attempt2
 		else:
-			print "Wrong named or non-existent tree"
+			print("Wrong named or non-existent tree")
 			sys.exit()
-		
+
 	phylotree = Tree(chosen_model_tree)
 else:
 	phylotree = Tree(args.input)
@@ -69,14 +71,14 @@ else:
 for node in phylotree.get_descendants():
 	if node.support < args.branch_support:
 		node.delete()
-tag = str(args.input[args.input.rfind("."):])
 
+tag = str(args.input[args.input.rfind("."):])
 
 if args.main != None:
 	central_seq = args.main
 else:
 	if os.path.isdir(args.input) == True:
-		central_seq = re.findall("[A-Z0-9]{4,10}_[A-Z0-9]{3,5}"+tag, args.input)[-1][:-6]
+		central_seq = re.findall("[A-Z0-9]{4,10}_[A-Z0-9]{3,5}" + tag, args.input)[-1][:-6]
 	else:
 		for seq in phylotree.get_leaves():
 			name = str(seq)[3:str(seq).find("|")]
@@ -84,7 +86,7 @@ else:
 				central_seq = re.findall("[A-Z0-9]{4,10}_[A-Z0-9]{3,5}", str(seq))[-1]
 				break
 		else:
-			raise IOError ("I don't know which one is the main sequence used for the tree. Maybe you can provide the name manually with the -m or --main flag")
+			raise IOError("I don't know which one is the main sequence used for the tree. Maybe you can provide the name manually with the -m or --main flag")
 
 
 central_sp = central_seq[central_seq.find("_")+1:]
@@ -92,68 +94,84 @@ taxofile = args.taxonomy
 if args.verbose == False:
 	outputfile = open(args.output, "a")
 
+
 ########################################################################
 '''Taxonomist will create a dictionary relating each mnemonic with the
 complete taxonomy of this organism'''
 
 taxo_dict = {}
 
-def taxonomist (taxofile):
+
+def taxonomist(taxofile, sep=";"):
 	for line in open(taxofile):
-		taxa = re.split('[,;]', line)
+		taxa = line.split(sep)
 		taxo_dict[taxa[1]] = taxa[2:10]
 	return taxo_dict
 
+
 ########################################################################
-'''Paperbag will create a dictionary relating each taxonomic term with 
+'''Paperbag will create a dictionary relating each taxonomic term with
 the species that are included in'''
 
 paperbag_dict = {}
 
-def paperbag (taxofile):
+
+def paperbag(taxofile, sep=";"):
 	termset = set()
-	paperbag_dict["biosphere"] = set()
-	paperbag_dict["biosphere"].add("BACTERIA")
-	paperbag_dict["biosphere"].add("ARCHAEA")
+	paperbag_dict["biosphere"] = set(["BACTERIA", "ARCHAEA"])
+	#  paperbag_dict["biosphere"].add("BACTERIA")
+	#  paperbag_dict["biosphere"].add("ARCHAEA")
 	paperbag_dict["eukaryota"] = set()
 	for line in open(taxofile):
-		if line[0] == "#": continue
+		if line[0] == "#":
+			continue
 		else:
-			cast = re.split('[,;]', line)
+			cast = line.split(sep)
 			for term in cast[2:10]:
 				termset.add(term)
 	for term in termset:
 		paperbag_dict[term] = set()
 	for line in open(taxofile):
-		if line[0] == "#": continue
+		if line[0] == "#":
+			continue
 		else:
-			elements = re.split('[,;]', line)
+			elements = line.split(sep)
 			for element in elements[2:10]:
 				paperbag_dict[element].add(elements[1])
 				paperbag_dict["biosphere"].add(elements[1])
 				paperbag_dict["eukaryota"].add(elements[1])
 	return paperbag_dict
 
+
 ########################################################################
-'''euka_exclusive will look at a phylogenetic tree and check if all 
+'''euka_exclusive will look at a phylogenetic tree and check if all
 branches are eukaryotic, and some related information'''
 
-def euka_exclusive (problem):
+
+def euka_exclusive(problemtree):
 	cast = set()
 	for leaf in problemtree.get_leaves():
 		cast.add(str(leaf)[str(leaf).rfind("_")+1:])
 	return cast.issubset(paperbag_dict["eukaryota"]), cast, cast.intersection(paperbag_dict["eukaryota"])
 
+
 ########################################################################
 '''Dinasty will search the common ancestor of all the mnemonics in a list'''
 
-def dinasty (spp_list):
+
+def dinasty(spp_list):
 	spp_tuple = tuple(spp_list)
 	commonancestor = ''
 	checkset = set()
 	switch = False
-	for i in range(len(taxo_dict["ARATH"])):
-		if switch == True: continue
+	set_len = {len(taxo_dict[k]) for k in taxo_dict.keys()}
+	if len(set_len) == 1:
+		level = tuple(set_len)[0]
+	else:
+		print("Warning: Different taxonomy sizes")
+	for i in range(level):
+		if switch == True:
+			continue
 		else:
 			for spp in spp_tuple:
 				if spp in taxo_dict.keys():
@@ -166,87 +184,75 @@ def dinasty (spp_list):
 			commonancestor = [taxo_dict[spp_list[0]][int(i)], int(i)]
 			break
 		else:
-			checkset = set() 
+			checkset = set()
 			continue
 	if commonancestor == '':
 		commonancestor = ["eukaryota", 8]
 	return commonancestor
 
+
 ########################################################################
-'''Get_mnemonics will use a phylotree or subset of it as inpunt and will return
+'''Get_mnemonics will use a phylotree or subset of it as input and will return
 a list containing all the mnemonics included in it'''
 
+
 def get_mnemonics(branch):
-	mnemoset = set()
-	mnemolist = []
-	for leaf in branch.get_leaves():
-		mnemoset.add(str(leaf)[str(leaf).rfind("_")+1:])
-	for element in mnemoset:
-		mnemolist.append(element)
+	mnemoset = {str(leaf)[str(leaf).rfind("_")+1:] for leaf in branch.get_leaves()}
+	mnemolist = [element for element in mnemoset]
 	return mnemolist
 
+
 ########################################################################
-'''Orthogroup will look at the sequence that is referred in the name of 
-the file. Then it will start climbing and checking the common ancestor 
+'''Orthogroup will look at the sequence that is referred in the name of
+the file. Then it will start climbing and checking the common ancestor
 between the first sequence and the sister branches. When the common ancestor
 of any of this sister branches is closer to the main sequence than the
-previous sister branch (a.k.a broken monophily) it will stop and will 
+previous sister branch (a.k.a broken monophily) it will stop and will
 select the monophiletic subtree for further analysis.
-
-Be noted that the name of the sequences contains the mnemonic of each 
+Be noted that the name of the sequences contains the mnemonic of each
 species, and thus must be extracted from there'''
 
-def orthogroup (phylotree):
+
+def orthogroup(phylotree):
 	main_leaf = ''
 	for leaf in phylotree.get_leaves():
 		if str(leaf).find(central_seq) > -1:
 			main_leaf = leaf
 			break
 	distance_to_main = 0.0
-	tree_root = ''			
-	for leaf in phylotree.iter_leaves(): #With this, the script will look at the farthest node to the central sequence and will select it as the root of the tree
+	tree_root = ''
+	for leaf in phylotree.iter_leaves():  # With this, the script will look at the furthest node to the central sequence and will select it as the root of the tree
 		if leaf.name != main_leaf:
 			if distance_to_main < main_leaf.get_distance(leaf):
 				distance_to_main = main_leaf.get_distance(leaf)
 				tree_root = leaf
-	phylotree.set_outgroup(tree_root) 		
+	phylotree.set_outgroup(tree_root)
 	output = main_leaf
-	prev_level = taxo_dict[central_sp][0]	
-	curr_level = taxo_dict[central_sp][0]
+	#  prev_level = taxo_dict[central_sp][0]  # Never used
+	#  curr_level = taxo_dict[central_sp][0]  # Never used
 	start_point = main_leaf
 	switch = False
 	leap = 0
 	rounds = 0
 	while rounds <= args.rounds and switch == False:
-		sis_mnemo, next_mnemo, combined_mnemo, para_mnemo, start_mnemo = [], [], [], [], []
-		sis_branch = start_point.get_sisters()	
+		sis_branch = start_point.get_sisters()
 		next_branch = start_point.get_common_ancestor(sis_branch).get_sisters()
 		start_mnemo = get_mnemonics(start_point)
-		#All this loops will stablish the phylogenetic relationships between the branches analyzed
-		for element in sis_branch:
-			for spp in get_mnemonics(element):
-				sis_mnemo.append(spp)
-		
-		for element in next_branch:
-			for spp in get_mnemonics(element):
-				next_mnemo.append(spp)
-		
-		for element in start_point: #This loop is needed so start_mnemo is independent from combined mnemo
-			for spp in get_mnemonics(element):
-				combined_mnemo.append(spp)
-		
-		for element in next_branch: #This loop is needed so para_mnemo is independent from next_mnemo
-			for spp in get_mnemonics(element):
-				para_mnemo.append(spp)
-		
-		
-		for element in sis_mnemo: #This step creates sets that combines start_point + sis_branch (combined) and sis_branch + next_branch (para)
-			combined_mnemo.append(element)
-			para_mnemo.append(element)
-			
+		# All this loops will stablish the phylogenetic relationships between the branches analyzed
+		sis_mnemo = [spp for element in sis_branch for spp in get_mnemonics(element)]
+
+		next_mnemo = [spp for element in next_branch for spp in get_mnemonics(element)]
+
+		# This step creates sets that combines start_point + sis_branch (combined) and sis_branch + next_branch (para)
+		# This loop is needed so start_mnemo is independent from combined mnemo
+		combined_mnemo = [spp for element in start_point for spp in get_mnemonics(element)] + [el for el in sis_mnemo]
+
+		# This loop is needed so para_mnemo is independent from next_mnemo
+		para_mnemo = [spp for element in next_branch for spp in get_mnemonics(element)] + [el for el in sis_mnemo]
+
 		start_dinasty, combined_dinasty, para_dinasty, next_dinasty, sis_dinasty = dinasty(start_mnemo), dinasty(combined_mnemo), dinasty(para_mnemo), dinasty(next_mnemo), dinasty(sis_mnemo)
 
-		if combined_dinasty[0] == "biosphere" and next_dinasty[0] == "biosphere" and (combined_dinasty[1] - start_dinasty[1]) >= args.jumps: #This means that at least one sequence in both sister_branch and next_branch is prokaryotic
+		if combined_dinasty[0] == "biosphere" and next_dinasty[0] == "biosphere" and (combined_dinasty[1] - start_dinasty[1]) >= args.jumps:  # This means that at least one sequence in both sister_branch and next_branch is prokaryotic
 			bacteria_purity = True
 			for element in sis_mnemo:
 				if element in taxo_dict.keys():
@@ -263,8 +269,8 @@ def orthogroup (phylotree):
 				switch = True
 				leap = combined_dinasty[1] - start_dinasty[1]
 				break
-			
-		elif combined_dinasty[0] != "biosphere" and next_dinasty[0] != "biosphere" and (combined_dinasty[1] - start_dinasty[1]) >= args.jumps: #This means that no prokaryotic sequence have been found so far neither in sis_branch nor in next_branch, but the taxonomic jump parameter has been met. It indicates a possible case of intereukaryotic HGT
+
+		elif combined_dinasty[0] != "biosphere" and next_dinasty[0] != "biosphere" and (combined_dinasty[1] - start_dinasty[1]) >= args.jumps:  # This means that no prokaryotic sequence have been found so far neither in sis_branch nor in next_branch, but the taxonomic jump parameter has been met. It indicates a possible case of intereukaryotic HGT
 			if paperbag_dict[start_dinasty[0]].issubset(paperbag_dict[para_dinasty[0]]) == False:
 				output = start_point.get_common_ancestor(next_branch)
 				switch = True
@@ -279,11 +285,15 @@ def orthogroup (phylotree):
 	return output, start_point, start_dinasty[0], sis_dinasty[0], leap
 
 ########################################################################
+
+
 '''Abaccus will check the tree extracted from orthogroup and will count
-the amount of gene loses that are needed to explain the given taxonomic 
+the amount of gene losses that are needed to explain the given taxonomic
 distribution'''
 
-def abaccus(suspect_tree, start_point, acceptor, donnor):
+
+# acceptor and donor are never atually refered
+def abaccus(suspect_tree, start_point):
 	observed_mnemo_list = set()
 	event_mnemo_list = []
 	wanted = []
@@ -291,12 +301,12 @@ def abaccus(suspect_tree, start_point, acceptor, donnor):
 		observed_mnemo_list.add(str(str(leaf)[str(leaf).rfind("_")+1:]))
 	for leaf in suspect_tree.get_leaves():
 		event_mnemo_list.append(str(str(leaf)[str(leaf).rfind("_")+1:]))
-	
+
 	commonancestor = dinasty(event_mnemo_list)
-	loses = 0
+	losses = 0
 	for i in range(commonancestor[1]):
 		if i > len(taxo_dict[central_sp]) - 1:
-			loses = loses + 1
+			losses = losses + 1
 			wanted.append("There is at least one loss in the base of eukarya")
 			break
 		elif set(paperbag_dict[taxo_dict[central_sp][i]]).issubset(observed_mnemo_list):
@@ -304,24 +314,25 @@ def abaccus(suspect_tree, start_point, acceptor, donnor):
 		elif len(set(paperbag_dict[taxo_dict[central_sp][i]]).difference(set(paperbag_dict[taxo_dict[central_sp][i-1]]))) == 0:
 			continue
 		else:
-			loses = loses +1
+			losses = losses + 1
 			wanted.append("There is at least one loss in " + taxo_dict[central_sp][i])
 			continue
-	return loses, wanted
-				
+	return losses, wanted
+
 ########################################################################
+
 
 taxonomist(taxofile)
 paperbag(taxofile)
 orthotree = orthogroup(phylotree)
 
-cutoff, jump = abaccus(orthotree[0], orthotree[1], orthotree[2], orthotree[3]), str(orthotree[4])
+cutoff, jump = abaccus(orthotree[0], orthotree[1]), str(orthotree[4])
 
-if cutoff[0] >= args.loses:
+if cutoff[0] >= args.losses:
 	if args.verbose == False:
-		outputfile.write("\n###" + central_seq + "###\n")
-		outputfile.write("#Minimal number of loses: " + str(cutoff[0]) + "\n")
-		outputfile.write("J == "+jump+" ; L == "+ str(cutoff[0])+". Cutoff values are J =< "+str(args.jumps)+" and L =< "+str(args.loses))
+		outputfile.write("\n###" + central_seq + ' - ' + taxo_dict[central_sp][0] + "###\n")
+		outputfile.write("Minimal number of losses: " + str(cutoff[0]) + "\n")
+		outputfile.write("J == " + jump + " ; L == " + str(cutoff[0]) + ". Cutoff values are J =< " + str(args.jumps) + " and L =< " + str(args.losses) + "\n")
 		for element in cutoff[1]:
 			outputfile.write(element)
 			outputfile.write("\n")
@@ -329,10 +340,14 @@ if cutoff[0] >= args.loses:
 		outputfile.write("\n\n\n")
 		outputfile.close()
 	if args.verbose == True:
-		print "###"+central_seq+"###"
-		print("#Minimal number of loses: " + str(cutoff[0]))
-		print("J == "+jump+" and L == "+ str(cutoff[0])+". Cutoff values are J => "+str(args.jumps)+" and L => "+str(args.loses))
+		print("###" + central_seq + "###")
+		print("Minimal number of losses: " + str(cutoff[0]))
+		print("J == " + jump + " and L == " + str(cutoff[0]) + ". Cutoff values are J => " + str(args.jumps) + " and L => " + str(args.losses) + "\n")
 		for element in cutoff[1]:
 			print(element)
 		print(orthotree[0])
-		print ("\n")
+		print("\n")
+else:
+	print('Minimal number of losses: ' + str(cutoff[0]))
+	print("J == " + jump + " and L == " + str(cutoff[0]) + ". Cutoff values are J => " + str(args.jumps) + " and L => " + str(args.losses))
+	print('No events detected, empty output file')


### PR DESCRIPTION
Dear all,

As requested by Prof. Gabaldon, I tried to update this script to make it python3/ETE3 compatible. First of all, thank you for providing me this insightful tool, I hope my other changes are in line with the work.

In order to test the changes I created two clean conda envs:

* one env had python2.7 and ete 2.3.10 with Abaccus1.0
* the other was with python3.6 and ete 3.1.2 with modified Abaccus

I checked and using the three examples the results were identical in both envs. I really hope I didn't miss any errors but maybe some further testing could be useful.

I did these minor changes:

* Whenever I could I removed for loops using list or set comprehension;
* I tweaked a bit the output. Notably, if no HGT is found the program now notices the user that the file is empty;
* Removed hard coding of ARATH in dinasty function;
* removed unused Abaccus function parameter: acceptor and donor, as they were not used;

Although I think I have a clear view of what the script does I have some doubts:

* why the thresholds were chosen this way? Meaning that, by design, L must be <= than J. So, there should not exist any case where J=2 and L=3. Therefore, based on my understanding, the defaults should be 3,3.
* Is the function euka_exlusive needed?

I had in mind to write a little script to define a function that takes as input ncbi taxon id and returns a taxonomy-like csv file, do you think that could be a good idea?

Finally, I propose to update software version to 1.1 and updated the README accordingly (I also updated it with ETE toolkit working link);

Regards and thanks again,\
Giacomo
